### PR TITLE
Hacker housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pypi.*key
 /Pipfile.lock
 /.tox/
 .eggs
+
+/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-build/
-dist/
-*.egg-info/
-__pycache__
+/build/
+/dist/
+/*.egg-info/
+__pycache__/
 pypi.*key
-Pipfile.lock
-.tox
+/Pipfile.lock
+/.tox/
 .eggs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,6 +44,12 @@ ALL_TARGETS += $(SOURCES.md:.md=.html)
 	$(MARKDOWN) -o $@ $<
 
 
+CHECK_SOURCES += soundcraft/
+CHECK_SOURCES += setup.py
+CHECK_SOURCES += test/
+CHECK_SOURCES += tools/
+
+
 # TODO: Eventually, there should be no FLAKE8_IGNORE content at all.
 
 # Import sequence and formatting
@@ -78,13 +84,13 @@ FLAKE8_FLAGS += --extend-ignore=$(shell echo "$(sort $(FLAKE8_IGNORE))" | tr ' '
 ALL_TARGETS += run-flake8
 .PHONY: run-flake8
 run-flake8:
-	$(FLAKE8) $(FLAKE8_FLAGS)
+	$(FLAKE8) $(FLAKE8_FLAGS) $(CHECK_SOURCES)
 
 
 ALL_TARGETS += run-black
 .PHONY: run-black
 run-black:
-	$(BLACK) .
+	$(BLACK) $(BLACK_FLAGS) $(CHECK_SOURCES)
 
 
 CHECK_TARGETS += check-pytest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -50,6 +50,12 @@ CHECK_SOURCES += test/
 CHECK_SOURCES += tools/
 
 
+ALL_TARGETS += run-contrib-to-about
+.PHONY: run-contrib-to-about
+run-contrib-to-about:
+	$(PYTHON) tools/contrib_to_about.py
+
+
 # TODO: Eventually, there should be no FLAKE8_IGNORE content at all.
 
 # Import sequence and formatting

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,7 +47,7 @@ ALL_TARGETS += $(SOURCES.md:.md=.html)
 # TODO: Eventually, there should be no FLAKE8_IGNORE content at all.
 
 # Import sequence and formatting
-FLAKE8_IGNORE += I100
+# FLAKE8_IGNORE += I100
 # FLAKE8_IGNORE += I201
 
 # I202 makes flake8 complain about a newline added by black. Have

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,97 @@
+# GNUmakefile - Automate a few tasks for hacking on soundcraft-utils
+#
+# This GNUmakefile is only to help while developing on
+# soundcraft-utils.
+#
+# It has nothing to do with actually building or installing
+# soundcraft-utils which goes by the well-known `setup.py` method.
+#
+# Targets:
+#    make        The same as `make all`.
+#    make all    Run code formatting checks, format sources properly.
+#    make check  Run all checks and tests, including those of 'make all'.
+
+
+########################################################################
+# Tools used
+########################################################################
+
+BLACK = black
+FLAKE8 = flake8
+MARKDOWN = markdown
+PYTEST = pytest
+TOX = tox
+
+
+########################################################################
+# Well-known make targets
+########################################################################
+
+.PHONY: all
+all: all-local
+
+.PHONY: check
+check: all check-local
+
+
+########################################################################
+# The actual targets to be hooked into the well-known targets
+########################################################################
+
+# TODO: Eventually, there should be no FLAKE8_IGNORE content at all.
+
+# Import sequence and formatting
+FLAKE8_IGNORE += I100
+FLAKE8_IGNORE += I201
+FLAKE8_IGNORE += I202
+
+# Missing docstrings
+FLAKE8_IGNORE += D100
+FLAKE8_IGNORE += D101
+FLAKE8_IGNORE += D102
+FLAKE8_IGNORE += D103
+FLAKE8_IGNORE += D104
+FLAKE8_IGNORE += D106
+FLAKE8_IGNORE += D107
+
+# Docstring contents
+FLAKE8_IGNORE += D200
+FLAKE8_IGNORE += D205
+FLAKE8_IGNORE += D208
+FLAKE8_IGNORE += D400
+
+FLAKE8_FLAGS += --extend-ignore=$(shell echo "$(sort $(FLAKE8_IGNORE))" | tr ' ' ,)
+
+ALL_TARGETS += run-flake8
+.PHONY: run-flake8
+run-flake8:
+	$(FLAKE8) $(FLAKE8_FLAGS)
+
+
+ALL_TARGETS += run-black
+.PHONY: run-black
+run-black:
+	$(BLACK) .
+
+
+CHECK_TARGETS += check-pytest
+.PHONY: check-pytest
+check-pytest:
+	$(PYTEST)
+
+
+CHECK_TARGETS += check-tox
+.PHONY: check-tox
+check-tox:
+	$(TOX)
+
+
+########################################################################
+# The hooking mechanism for the the well-known targets
+########################################################################
+
+.PHONY: all-local
+all-local: $(ALL_TARGETS)
+
+.PHONY: check-local
+check-local: $(CHECK_TARGETS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ ALL_TARGETS += $(SOURCES.md:.md=.html)
 
 # Import sequence and formatting
 FLAKE8_IGNORE += I100
-FLAKE8_IGNORE += I201
+# FLAKE8_IGNORE += I201
 
 # I202 makes flake8 complain about a newline added by black. Have
 # flake8 ignore it to allow a consistent state of affairs.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -49,6 +49,9 @@ ALL_TARGETS += $(SOURCES.md:.md=.html)
 # Import sequence and formatting
 FLAKE8_IGNORE += I100
 FLAKE8_IGNORE += I201
+
+# I202 makes flake8 complain about a newline added by black. Have
+# flake8 ignore it to allow a consistent state of affairs.
 FLAKE8_IGNORE += I202
 
 # Missing docstrings

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,6 +67,9 @@ FLAKE8_IGNORE += D107
 FLAKE8_IGNORE += D200
 FLAKE8_IGNORE += D205
 FLAKE8_IGNORE += D208
+
+# The DBUS XML in the docstrings cannot have the first line ending in
+# a period, so we need to ignore D400.
 FLAKE8_IGNORE += D400
 
 FLAKE8_FLAGS += --extend-ignore=$(shell echo "$(sort $(FLAKE8_IGNORE))" | tr ' ' ,)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,13 +63,14 @@ FLAKE8_IGNORE += D104
 FLAKE8_IGNORE += D106
 FLAKE8_IGNORE += D107
 
-# Docstring contents
-FLAKE8_IGNORE += D200
+# The DBUS XML in the class docstrings in notepad/dbus.py is a bit
+# weird for a docstring, so we need to ignore a few errors:
+#
+#   * D205 1 blank line required between summary line and description
+#   * D208 Docstring is over-indented
+#   * D400 First line should end with a period
 FLAKE8_IGNORE += D205
 FLAKE8_IGNORE += D208
-
-# The DBUS XML in the docstrings cannot have the first line ending in
-# a period, so we need to ignore D400.
 FLAKE8_IGNORE += D400
 
 FLAKE8_FLAGS += --extend-ignore=$(shell echo "$(sort $(FLAKE8_IGNORE))" | tr ' ' ,)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,6 +38,12 @@ check: all check-local
 # The actual targets to be hooked into the well-known targets
 ########################################################################
 
+SOURCES.md = $(wildcard *.md)
+ALL_TARGETS += $(SOURCES.md:.md=.html)
+%.html: %.md
+	$(MARKDOWN) -o $@ $<
+
+
 # TODO: Eventually, there should be no FLAKE8_IGNORE content at all.
 
 # Import sequence and formatting

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,8 +1,21 @@
-Notes for those wanting to help out:
+Notes for those wanting to help out
+===================================
 
 - Thank you!  I appreciate all feedback, pull requests, and gentle criticism!
-- Open pull requests to the default branch, currently named `release`
-- Please ensure that `pytest` passes, using `pytest` itself or `tox`.  Github runs this for you on all branches as well, and I'm working on getting the feedback from that integrated into the pull requests, eventually.
--- Try to test new code thoroughly.  I'm working on increasing code coverage as I go as well
-- Run `flake8` and `black` to format your code
-- Add yourself to the CONTRIBUTORS.md file if you want, but if you do, please also run `tools/contrib_to_about.py` to synchronize the changes in there to the GUI about screen.
+
+- Open pull requests to the default branch, currently named `release`.
+
+- Please ensure that `pytest` passes, using `pytest` itself or `tox`.
+
+  Github runs this for you on all branches as well, and I'm working on
+  getting the feedback from that integrated into the pull requests,
+  eventually.
+
+- Try to test new code thoroughly.  I'm working on increasing code
+  coverage as I go as well.
+
+- Run `flake8` and `black` to format your code.
+
+- Add yourself to the [`CONTRIBUTORS.md`](CONTRIBUTORS.html) file if you
+  want, but if you do, please also run `tools/contrib_to_about.py` to
+  synchronize the changes in there to the GUI about screen.

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,3 +19,22 @@ Notes for those wanting to help out
 - Add yourself to the [`CONTRIBUTORS.md`](CONTRIBUTORS.html) file if you
   want, but if you do, please also run `tools/contrib_to_about.py` to
   synchronize the changes in there to the GUI about screen.
+
+
+Interfaces, Namespaces, Specifications
+======================================
+
+This lists and links to (at least some) interfaces, namespaces, and
+specifications which `soundcraft-utils` comes into contact with.
+
+  * [DBUS](https://dbus.freedesktop.org/doc/dbus-specification.html)
+
+  * [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)
+
+    The `.desktop` file hooks the `soundcraft_gui` GUI application
+    into the desktop environment's list of applications.
+
+  * [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+    This specifies the locations the soundcraft-utils Desktop file and
+    icons should be installed to.

--- a/soundcraft/dbus.py
+++ b/soundcraft/dbus.py
@@ -35,6 +35,7 @@ except ModuleNotFoundError:
     raise
 gi.require_version("GUdev", "1.0")
 from gi.repository import GLib, GUdev
+
 from pydbus import SystemBus
 from pydbus.generic import signal
 

--- a/soundcraft/gui.py
+++ b/soundcraft/gui.py
@@ -21,14 +21,14 @@
 
 import sys
 import traceback
-from pathlib import Path
 from collections.abc import Iterable
+from pathlib import Path
 
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import Gtk
 
 import soundcraft
 from soundcraft.dbus import Client, DbusInitializationError, VersionIncompatibilityError

--- a/test/test_notepad.py
+++ b/test/test_notepad.py
@@ -5,7 +5,7 @@ import pytest
 
 import usb.core
 
-from soundcraft import notepad
+from soundcraft import notepad  # noqa: I100
 
 
 class UsbCoreMock:

--- a/test/test_notepad.py
+++ b/test/test_notepad.py
@@ -2,7 +2,9 @@ import array
 from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
+
 import usb.core
+
 from soundcraft import notepad
 
 

--- a/tools/contrib_to_about.py
+++ b/tools/contrib_to_about.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 
-import re
 import os
+import re
 
 author_format = re.compile(
     r"^- \[(?P<name>[^]]+)]\(mailto:(?P<email>[^)]+)\)(?P<description>.*)"


### PR DESCRIPTION
This does some housekeeping for hackers:

  * make gitignore patterns more specific
  * makes the source code formatting and code testing suggested by `HACKING.md` easily available by `make` and `make check`
  * helps with writing `*.md` files by converting them to `*.html'
  * goes through all errors reported by `flake8` and starts fixing a number of them

Feel free to compla^Wcomment and cherrypick.
