### PR TITLE
Hacker housekeeping 2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,6 @@ ignore =
     E501,
     E402,
     F541,
+    # I202 makes flake8 complain about a newline which black insists
+    # on adding. So we have flake8 ignore it to avoid flapping.
+    I202,

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,9 @@
 [flake8]
+exclude =
+    .git,
+    __pycache__,
+    _root,
+    build,
+    dist,
+    .tox,
 ignore = E501, E402, F541

--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,12 @@ ignore =
     # I202 makes flake8 complain about a newline which black insists
     # on adding. So we have flake8 ignore it to avoid flapping.
     I202,
+    # The DBUS XML in the class docstrings in notepad/dbus.py is a bit
+    # weird for a docstring, so we need to ignore a few errors:
+    #
+    #   * D205 1 blank line required between summary line and description
+    #   * D208 Docstring is over-indented
+    #   * D400 First line should end with a period
+    D205,
+    D208,
+    D400,

--- a/.flake8
+++ b/.flake8
@@ -6,4 +6,7 @@ exclude =
     build,
     dist,
     .tox,
-ignore = E501, E402, F541
+ignore =
+    E501,
+    E402,
+    F541,

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-build/
-dist/
-*.egg-info/
-__pycache__
+/build/
+/dist/
+/*.egg-info/
+__pycache__/
 pypi.*key
-Pipfile.lock
-.tox
+/Pipfile.lock
+/.tox/
 .eggs

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,8 +1,21 @@
-Notes for those wanting to help out:
+Notes for those wanting to help out
+===================================
 
 - Thank you!  I appreciate all feedback, pull requests, and gentle criticism!
-- Open pull requests to the default branch, currently named `release`
-- Please ensure that `pytest` passes, using `pytest` itself or `tox`.  Github runs this for you on all branches as well, and I'm working on getting the feedback from that integrated into the pull requests, eventually.
--- Try to test new code thoroughly.  I'm working on increasing code coverage as I go as well
-- Run `flake8` and `black` to format your code
-- Add yourself to the CONTRIBUTORS.md file if you want, but if you do, please also run `tools/contrib_to_about.py` to synchronize the changes in there to the GUI about screen.
+
+- Open pull requests to the default branch, currently named `release`.
+
+- Please ensure that `pytest` passes, using `pytest` itself or `tox`.
+
+  Github runs this for you on all branches as well, and I'm working on
+  getting the feedback from that integrated into the pull requests,
+  eventually.
+
+- Try to test new code thoroughly.  I'm working on increasing code
+  coverage as I go as well.
+
+- Run `flake8` and `black` to format your code.
+
+- Add yourself to the [`CONTRIBUTORS.md`](CONTRIBUTORS.html) file if you
+  want, but if you do, please also run `tools/contrib_to_about.py` to
+  synchronize the changes in there to the GUI about screen.

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,3 +19,22 @@ Notes for those wanting to help out
 - Add yourself to the [`CONTRIBUTORS.md`](CONTRIBUTORS.html) file if you
   want, but if you do, please also run `tools/contrib_to_about.py` to
   synchronize the changes in there to the GUI about screen.
+
+
+Interfaces, Namespaces, Specifications
+======================================
+
+This lists and links to (at least some) interfaces, namespaces, and
+specifications which `soundcraft-utils` comes into contact with.
+
+  * [DBUS](https://dbus.freedesktop.org/doc/dbus-specification.html)
+
+  * [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)
+
+    The `.desktop` file hooks the `soundcraft_gui` GUI application
+    into the desktop environment's list of applications.
+
+  * [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+
+    This specifies the locations the soundcraft-utils Desktop file and
+    icons should be installed to.

--- a/soundcraft/dbus.py
+++ b/soundcraft/dbus.py
@@ -35,6 +35,7 @@ except ModuleNotFoundError:
     raise
 gi.require_version("GUdev", "1.0")
 from gi.repository import GLib, GUdev
+
 from pydbus import SystemBus
 from pydbus.generic import signal
 

--- a/soundcraft/gui.py
+++ b/soundcraft/gui.py
@@ -21,14 +21,14 @@
 
 import sys
 import traceback
-from pathlib import Path
 from collections.abc import Iterable
+from pathlib import Path
 
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import Gtk
 
 import soundcraft
 from soundcraft.dbus import Client, DbusInitializationError, VersionIncompatibilityError

--- a/test/test_notepad.py
+++ b/test/test_notepad.py
@@ -5,7 +5,7 @@ import pytest
 
 import usb.core
 
-from soundcraft import notepad
+from soundcraft import notepad  # noqa: I100
 
 
 class UsbCoreMock:

--- a/test/test_notepad.py
+++ b/test/test_notepad.py
@@ -2,7 +2,9 @@ import array
 from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
+
 import usb.core
+
 from soundcraft import notepad
 
 

--- a/tools/contrib_to_about.py
+++ b/tools/contrib_to_about.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 
-import re
 import os
+import re
 
 author_format = re.compile(
     r"^- \[(?P<name>[^]]+)]\(mailto:(?P<email>[^)]+)\)(?P<description>.*)"


### PR DESCRIPTION
This is a reordered and rebased and rearranged sequence of the commits from https://github.com/lack/soundcraft-utils/pull/10:

  * extends `HACKING.md` a bit
  * tightens the `.gitignore` pattern specifications a bit
  * goes through some of the errors `flake8` complains about, fixing some, and permanently ignoring others

Only then anything makefile related begins at https://github.com/lack/soundcraft-utils/commit/2a20a1cd2ada361c8b18aa9d49464e60ce79ae5e, which needs more discussion/changes/rewrites.
