### PR TITLE
Use decimal conversion without string manipulation

### DIFF
--- a/soundcraft/dbus.py
+++ b/soundcraft/dbus.py
@@ -204,8 +204,8 @@ class Service:
                     )
         elif action == "remove" and self.hasDevice():
             # UDEV adds leading 0s to decimal numbers.  They're not octal.  Why??
-            busnum = int(device.get_property("BUSNUM").lstrip("0"))
-            devnum = int(device.get_property("DEVNUM").lstrip("0"))
+            busnum = int(device.get_property("BUSNUM"), 10)
+            devnum = int(device.get_property("DEVNUM"), 10)
             objectdev = self.object._wrapped._dev.dev
             if busnum == objectdev.bus and devnum == objectdev.address:
                 self.unregister()


### PR DESCRIPTION
Decimally convert a string with leading zeros to an integer
value without string manipulation.

  * Makes the conversion successfully return an integer value
    of `0` in case someone were to feed it a string like `"000"`,
    even if that is unlikely to happen.

  * Makes the decimal conversion code work exactly like the
    hexadecimal conversion code 13 lines above.

  * Avoids the use of string manipulations for a number.

  * The extra `base=` parameter for `int()` of value `10` is not
    stricly necessary, as `int()` is defined as

        int(x, base=10) -> integer

    However, the explicit value `10` makes the intention of the
    code absolutely obvious, even to someone reading the code who
    mistakenly assumes Python's `int()` function interprets
    leading zeros to mean octal numbers like e.g. C would.