### PR TITLE
contrib: Add a place for helpful files

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,14 @@
+The files in contrib/
+=====================
+
+The files in `contrib/` are intended to be examples helpful
+illustrations when installing, configuring, and using
+`soundcraft-utils`, mainly by giving some ideas which can help you
+find a solution.
+
+These files are not intended to be working out of the box, be
+documented flawlessly, or be useful for everybody.
+
+If one of these files directly works for you unmodified, that is a
+lucky coincidence. Otherwise, use modified copies of them or use them
+as inspiration for your own solutions.

--- a/contrib/dbus-stuff/start-dbus-service.sh
+++ b/contrib/dbus-stuff/start-dbus-service.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+busname="soundcraft.utils.notepad"
+
+set -xe
+
+# Start the soundcraft-utils dbus service via bus activation on the system bus
+
+# dbus-send --system --print-reply --dest=org.freedesktop.DBus \
+#	  /org/freedesktop/DBus org.freedesktop.DBus.StartServiceByName \
+#	  "string:${busname}" uint32:0
+
+busctl call org.freedesktop.DBus /org/freedesktop/DBus \
+       org.freedesktop.DBus StartServiceByName su "${busname}" 0
+
+sleep 2
+
+# See what objects the soundcraft-utils dbus service exposes on the system bus
+# Note that busctl has beautiful bash shell completion for bus names etc.
+
+busctl tree "${busname}"
+busctl --no-pager introspect "${busname}" /soundcraft/utils/notepad/0
+
+busctl get-property "${busname}" /soundcraft/utils/notepad/0 \
+       soundcraft.utils.notepad.device sources
+
+busctl get-property "${busname}" /soundcraft/utils/notepad/0 \
+       soundcraft.utils.notepad.device routingSource
+
+busctl set-property "${busname}" /soundcraft/utils/notepad/0 \
+       soundcraft.utils.notepad.device routingSource s INPUT_7_8

--- a/contrib/udev-rules/70-soundcraft-utils.rules
+++ b/contrib/udev-rules/70-soundcraft-utils.rules
@@ -1,0 +1,4 @@
+# Soundcraft Notepad 5, Notepad 8FX and Notepad 12FX analog mixers with USB control
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0030", TAG+="uaccess"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0031", TAG+="uaccess"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0032", TAG+="uaccess"

--- a/contrib/udev-rules/80-soundcraft-utils.rules
+++ b/contrib/udev-rules/80-soundcraft-utils.rules
@@ -1,0 +1,4 @@
+# Soundcraft Notepad 5, Notepad 8FX and Notepad 12FX analog mixers with USB control
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0030", GROUP="audio"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0031", GROUP="audio"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0032", GROUP="audio"

--- a/contrib/udev-rules/90-soundcraft-utils.rules
+++ b/contrib/udev-rules/90-soundcraft-utils.rules
@@ -1,0 +1,4 @@
+# Soundcraft Notepad 5, Notepad 8FX and Notepad 12FX analog mixers with USB control
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0030", ENV{DEVNAME}!="", RUN+="/usr/bin/setfacl -m u:someuser:rw '$env{DEVNAME}'"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0031", ENV{DEVNAME}!="", RUN+="/usr/bin/setfacl -m u:someuser:rw '$env{DEVNAME}'"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="05fc", ATTRS{idProduct}=="0032", ENV{DEVNAME}!="", RUN+="/usr/bin/setfacl -m u:someuser:rw '$env{DEVNAME}'"


### PR DESCRIPTION
[Quoting the newly added `contrib/README.md`:]

The files in `contrib/` are intended to be examples helpful
illustrations when installing, configuring, and using
`soundcraft-utils`, mainly by giving some ideas which can help
you find a solution.

These files are not intended to be working out of the box, be
documented flawlessly, or be useful for everybody.

If one of these files directly works for you unmodified, that
is a lucky coincidence. Otherwise, use modified copies of them
or use them as inspiration for your own solutions.