### PR TITLE
Avoid mutable parameter default value objects

### DIFF
--- a/soundcraft/notepad.py
+++ b/soundcraft/notepad.py
@@ -40,8 +40,10 @@ def autodetect(stateDir=DEFAULT_STATEDIR):
 
 class NotepadBase:
     def __init__(
-        self, idProduct, routingTarget, stateDir=DEFAULT_STATEDIR, fixedRouting=[],
+        self, idProduct, routingTarget, stateDir=DEFAULT_STATEDIR, fixedRouting=None,
     ):
+        if fixedRouting is None:
+            fixedRouting = []
         self.routingTarget = routingTarget
         self.fixedRouting = fixedRouting
         self.stateDir = stateDir


### PR DESCRIPTION
As those objects only exist once per function, any possible changes
of their value have a global effect which is rarely intended.

The current code does not change self.fixedRouting (it only assigns
to it), but the code might change sometime later, introducing weird
and subtle bugs, so we avoid that problem right now.

Note that Python strings and pathlib.Path objects are immutable, so
the parameter default values of those types do not exhibit the
problem and therefore can be left untouched.