### PR TITLE
Add `--version` argument to all installed scripts

### DIFF
--- a/soundcraft/cli.py
+++ b/soundcraft/cli.py
@@ -22,6 +22,8 @@
 import argparse
 import sys
 
+from . import __version__
+
 
 def autodetect(dbus=True):
     if dbus:
@@ -83,6 +85,11 @@ def show(dev):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s (soundcraft-utils) {__version__}",
+    )
     parser.add_argument(
         "--no-dbus",
         help="Use direct USB device access instead of DBUS service access",

--- a/soundcraft/dbus.py
+++ b/soundcraft/dbus.py
@@ -455,6 +455,11 @@ class Client:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s (soundcraft-utils) {soundcraft.__version__}",
+    )
+    parser.add_argument(
         "--setup",
         help="Set up the dbus configuration in /usr/share/dbus-1 (Must be run as root)",
         action="store_true",

--- a/soundcraft/gui.py
+++ b/soundcraft/gui.py
@@ -27,6 +27,7 @@ from collections.abc import Iterable
 import gi
 
 gi.require_version("Gtk", "3.0")
+from gi.repository import GLib
 from gi.repository import Gtk
 from gi.repository import Gio
 
@@ -237,8 +238,36 @@ class About(Gtk.AboutDialog):
 
 class App(Gtk.Application):
     def __init__(self):
-        super().__init__(application_id="soundcraft.utils")
+        super().__init__(
+            application_id="soundcraft.utils",
+            flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
+        )
         self.window = None
+
+        self.add_main_option(
+            "version",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.NONE,
+            "Show program's version number and exit",
+            None,
+        )
+
+    def __cmdline_version(self):
+        prog = Path(sys.argv[0])
+        print(f"{prog.name} (soundcraft-utils) {soundcraft.__version__}")
+        return 0
+
+    def do_command_line(self, command_line):
+        options = command_line.get_options_dict()
+        # convert GVariantDict -> GVariant -> dict
+        options = options.end().unpack()
+
+        if "version" in options:
+            return self.__cmdline_version()
+
+        self.activate()
+        return 0
 
     def do_activate(self):
         if self.window is not None:


### PR DESCRIPTION
Add a `--version` argument to all installed scripts which prints
a basic version information message for good form.

This also establishes how to add a command line argument to the
Gtk app. That might come in useful later, e.g. when adding a
`--no-dbus` option for the Gtk app.

Note that if you wanted to have a more complex multiline version
information message like e.g. the GNU tools do, you cannot use
the `argparse` `action="version"` because argparse internally
interprets newlines in the `version=` message just like any other
whitespace character.