### PR TITLE
tools/link_system_libs: Made it idempotent

### DIFF
--- a/tools/link_system_libs
+++ b/tools/link_system_libs
@@ -39,8 +39,13 @@ echo "Found system libpath for $LIB: $LIBPATH"
 
 envpaths=$(libpaths "pipenv run python3")
 for path in $envpaths; do
+    linkpath="$path/$(basename "$LIBPATH")"
+    if test -L "$linkpath" && test "x$(readlink "$linkpath")" = "x$LIBPATH"; then
+	echo "Nothing to do: $linkpath already pointing to $LIBPATH"
+	break
+    fi
     echo "Trying to link $LIB into envpath $path"
-    ln -s "$LIBPATH" "$path"
+    ln -s "$LIBPATH" "$linkpath"
     if [[ $? == 0 ]]; then
         echo "Success"
         break


### PR DESCRIPTION
Repeated runs of `tools/link_system_libs` used to produce
error messages like

    ln: failed to create symbolic link '/home/user/.local/share/virtualenvs/soundcraft-utils-ABCDEFG/lib/python3.8/site-packages/gi': File exists

Now the script checks if the symlink already exists and
points to the correct place, and will accept that as a
successful script run as well.

If the symlink already exists and points to the wrong place,
an error message will still be produced.